### PR TITLE
Case insensitive matching of emails

### DIFF
--- a/src/bin/loginhuset.rs
+++ b/src/bin/loginhuset.rs
@@ -148,7 +148,7 @@ fn mailgun_request(email: &str, config: Rc<Mailgun>, url: &str) -> hyper::Reques
 
 fn get_user(user_email: &str, db_conn: &SqliteConnection) -> Option<User> {
     use ::loginhuset::schema::users::dsl::*;
-    users.filter(email.eq(user_email))
+    users.filter(email.to_lowercase().eq(user_email.to_lowercase()))
         .first::<User>(&*db_conn)
         .optional()
         .expect("Failed to find users table")


### PR DESCRIPTION
... yes... email usernames are actually technically case sensitive, but what major provider in their right mind treat them as such?

So, let's trade "well, actually" for UX :P